### PR TITLE
[feat] 로그인, 영업 메인 페이지, 영업 네비 바 추가

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/propozal-frontend/package-lock.json
+++ b/propozal-frontend/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.1.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.7.1",
         "react-scripts": "^5.0.1"
       },
@@ -14714,6 +14715,15 @@
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -17724,9 +17734,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -17734,7 +17744,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/propozal-frontend/package.json
+++ b/propozal-frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^19.1.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.7.1",
     "react-scripts": "^5.0.1"
   },

--- a/propozal-frontend/src/App.jsx
+++ b/propozal-frontend/src/App.jsx
@@ -4,17 +4,22 @@ import Layout from './components/Layout/Layout';
 import Home from './pages/Home/Home';
 import Login from './pages/Login/Login';
 import Signup from './pages/Signup/Signup';
+// import EstimateDetail from './pages/EstimateDetail/EstimateDetail'; // 📌 견적서 조회 페이지
+import SalesMainPage from './pages/SalesMainPage/SalesMainPage'; // ✅ 세일즈 메인 페이지 추가
 
 const App = () => {
   return (
     <Routes>
+      {/* 공통 레이아웃이 필요한 페이지들 */}
       <Route path="/" element={<Layout><Home /></Layout>} />
-      <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<Layout><Signup /></Layout>} />
+{/*       <Route path="/estimate" element={<Layout><EstimateDetail /></Layout>} /> */}
 
+      {/* 레이아웃이 필요 없는 페이지들 */}
+      <Route path="/login" element={<Login />} />
+      <Route path="/sales" element={<SalesMainPage />} /> {/* ✅ 세일즈 전용 페이지 */}
     </Routes>
   );
 };
 
 export default App;
-

--- a/propozal-frontend/src/components/Navbar/SalesNavbar.css
+++ b/propozal-frontend/src/components/Navbar/SalesNavbar.css
@@ -1,0 +1,65 @@
+/* src/components/Navbar.css */
+
+.custom-navbar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* src/components/Navbar/Navbar.css */
+
+.logo {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  font-size: 24px;
+  display: flex;
+  align-items: center;
+  margin-left: 24px; /* 왼쪽에서 살짝 떨어지게 */
+}
+
+.logo .pro {
+  color: #588157;
+}
+
+.logo .pozal {
+  color: #000000;
+}
+
+.login-btn {
+  margin-right: 24px; /* 오른쪽 끝에서 떨어지게 */
+}
+
+.login-btn:hover {
+  background-color: #198754 !important;
+  color: #fff !important;
+  border-color: #000000 !important;
+  transition: all 0.3s ease;
+}
+
+.nav-tab-group {
+  display: flex;
+  gap: 10px; /* ✅ 각 메뉴 간 간격 설정 */
+}
+
+.nav-tab-group .nav-link {
+  padding: 6px 12px;
+  font-weight: 500;
+  border-radius: 6px;
+  transition: background-color 0.3s ease;
+  text-decoration: none;
+  color: #333;
+}
+
+.nav-tab-group .nav-link:hover {
+  background-color: #f8f9fa;
+}
+
+/* 로그인 버튼은 기존대로 유지되지만 필요시 간격 조정 */
+.login-btn {
+  margin-left: 10px;
+}
+
+
+

--- a/propozal-frontend/src/components/Navbar/SalesNavbar.jsx
+++ b/propozal-frontend/src/components/Navbar/SalesNavbar.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
+import "bootstrap/dist/css/bootstrap.min.css";
+import "bootstrap/dist/js/bootstrap.bundle.min";
+import "./SalesNavbar.css"; // 커스텀 스타일 (위치 고정 등)
+
+const SalesNavbar = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    // 메뉴 닫기: 이동 시 collapse 영역 닫기
+    const nav = document.getElementById("mainNav");
+    if (nav && nav.classList.contains("show")) {
+      nav.classList.remove("show");
+    }
+  }, [location]); // location 변경될 때마다 실행됨
+
+  return (
+    <nav className="navbar navbar-expand-lg navbar-light bg-light custom-navbar">
+      <div className="container-fluid">
+        {/* 🔰 로고 */}
+        <Link className="navbar-brand logo" to="/">
+          <span className="pro">Pro</span>
+          <span className="pozal">poZal</span>
+        </Link>
+
+        {/* ☰ 모바일 햄버거 */}
+        <button
+          className="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#mainNav"
+          aria-controls="mainNav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span className="navbar-toggler-icon" />
+        </button>
+
+        {/* 🔗 네비게이션 링크 */}
+        <div className="collapse navbar-collapse" id="mainNav">
+          <ul className="navbar-nav ms-auto align-items-center nav-tab-group">
+            <li className="nav-item">
+              <Link className="nav-link" to="/">홈</Link>
+            </li>
+            <li className="nav-item">
+              <Link className="nav-link" to="#">견적서</Link>
+            </li>
+            <li className="nav-item">
+              <Link className="nav-link" to="#">제품 탐색</Link>
+            </li>
+            <li className="nav-item">
+              <Link className="nav-link" to="#">스케줄 관리</Link>
+            </li>
+            <li className="nav-item">
+              <Link className="btn btn-outline-dark rounded-pill px-3 py-1 login-btn" to="/login">
+                나의 프로필
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default SalesNavbar;

--- a/propozal-frontend/src/components/SalesMainPage/MainIcon.css
+++ b/propozal-frontend/src/components/SalesMainPage/MainIcon.css
@@ -1,0 +1,22 @@
+/* src/components/SalesMainPage/MainIcon.css */
+
+.card-custom-bg {
+  background-color: #f8f9fa; /* 밝은 회색 배경 */
+}
+
+.main-icon-green {
+  color: #198754; /* 아이콘 초록색 */
+}
+
+.btn-go-green {
+  color: #198754;
+  border: 2px solid #198754;
+  background-color: transparent;
+  transition: all 0.3s ease;
+}
+
+.btn-go-green:hover {
+  background-color: #198754;
+  color: #ffffff;
+  border-color: #198754;
+}

--- a/propozal-frontend/src/components/SalesMainPage/MainIcon.jsx
+++ b/propozal-frontend/src/components/SalesMainPage/MainIcon.jsx
@@ -1,0 +1,48 @@
+// // src/components/SalesMainPage/MainIcon.jsx
+// import React from "react";
+// import { Card, Button } from "react-bootstrap";
+// // import "./MainIcon.css";
+//
+// const MainIcon = ({ icon, title, link }) => {
+//   return (
+//     <Card className="text-center shadow-sm rounded-4 border-0 h-100">
+//       <Card.Body className="d-flex flex-column justify-content-between">
+//         <div className="mb-3 text-primary">{icon}</div>
+//         <h5 className="fw-bold mb-3">{title}</h5>
+//         <Button
+//           variant="outline-primary"
+//           className="rounded-pill px-4 py-2 mt-auto"
+//           href={link}
+//         >
+//           바로가기
+//         </Button>
+//       </Card.Body>
+//     </Card>
+//   );
+// };
+//
+// export default MainIcon;
+
+// src/components/SalesMainPage/MainIcon.jsx
+import React from "react";
+import { Card, Button } from "react-bootstrap";
+import "./MainIcon.css";
+
+const MainIcon = ({ icon, title, link }) => {
+  return (
+    <Card className="text-center shadow-sm rounded-4 border-0 h-100 card-custom-bg">
+      <Card.Body className="d-flex flex-column justify-content-between">
+        <div className="mb-3 main-icon-green">{icon}</div>
+        <h5 className="fw-bold mb-3">{title}</h5>
+        <Button
+          className="btn-go-green rounded-pill px-4 py-2 mt-auto"
+          href={link}
+        >
+          바로가기
+        </Button>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default MainIcon;

--- a/propozal-frontend/src/components/SalesMainPage/MainIconGroup.jsx
+++ b/propozal-frontend/src/components/SalesMainPage/MainIconGroup.jsx
@@ -1,0 +1,37 @@
+// src/components/SalesMainPage/MainIconGroup.jsx
+import React from "react";
+import { Row, Col } from "react-bootstrap";
+import { FaFileSignature, FaFileAlt, FaCalendarAlt } from "react-icons/fa";
+import MainIcon from "./MainIcon";
+
+const iconData = [
+  {
+    icon: <FaFileSignature size={40} />,
+    title: "견적서 작성",
+    link: "/create-quotation",
+  },
+  {
+    icon: <FaFileAlt size={40} />,
+    title: "견적서 조회",
+    link: "/view-quotation",
+  },
+  {
+    icon: <FaCalendarAlt size={40} />,
+    title: "스케줄 조회",
+    link: "/view-schedule",
+  },
+];
+
+const MainIconGroup = () => {
+  return (
+    <Row className="g-4 justify-content-center">
+      {iconData.map((item, idx) => (
+        <Col key={idx} xs={10} sm={6} md={4}>
+          <MainIcon icon={item.icon} title={item.title} link={item.link} />
+        </Col>
+      ))}
+    </Row>
+  );
+};
+
+export default MainIconGroup;

--- a/propozal-frontend/src/components/SalesMainPage/ScheduleBox.css
+++ b/propozal-frontend/src/components/SalesMainPage/ScheduleBox.css
@@ -1,0 +1,34 @@
+.schedule-box-wrapper {
+  display: flex;
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.schedule-date {
+  background-color: #e9ecef;
+  padding: 1rem;
+  font-weight: 600;
+  color: #495057;
+  min-width: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.schedule-detail {
+  background-color: #ffffff;
+  padding: 1rem 1.2rem;
+  flex: 1;
+}
+
+.schedule-time {
+  font-weight: bold;
+  color: #198754;
+  margin-bottom: 0.5rem;
+}
+
+.schedule-desc {
+  color: #333;
+}

--- a/propozal-frontend/src/components/SalesMainPage/ScheduleBox.jsx
+++ b/propozal-frontend/src/components/SalesMainPage/ScheduleBox.jsx
@@ -1,0 +1,17 @@
+// src/components/SalesMainPage/ScheduleBox.jsx
+import React from "react";
+import "./ScheduleBox.css";
+
+const ScheduleBox = ({ date, time, description }) => {
+  return (
+    <div className="schedule-box-wrapper">
+      <div className="schedule-date">{date}</div>
+      <div className="schedule-detail">
+        <div className="schedule-time">{time}</div>
+        <div className="schedule-desc">{description}</div>
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleBox;

--- a/propozal-frontend/src/components/SalesMainPage/ScheduleListGroup.css
+++ b/propozal-frontend/src/components/SalesMainPage/ScheduleListGroup.css
@@ -1,0 +1,9 @@
+.schedule-list-group {
+  padding: 1rem 0;
+}
+
+.upcoming-wrapper {
+  background-color: #f8f9fa;
+  padding: 1rem;
+  border-radius: 12px;
+}

--- a/propozal-frontend/src/components/SalesMainPage/ScheduleListGroup.jsx
+++ b/propozal-frontend/src/components/SalesMainPage/ScheduleListGroup.jsx
@@ -1,0 +1,81 @@
+// // src/components/SalesMainPage/ScheduleListGroup.jsx
+// import React from "react";
+// import { Container } from "react-bootstrap";
+// import ScheduleBox from "./ScheduleBox";
+//
+// const ScheduleListGroup = () => {
+//   const nearestSchedule = {
+//     date: "2025-08-20",
+//     time: "09:00",
+//     description: "XX사 물품 관련 발주 회의 미팅",
+//   };
+//
+//   const upcomingSchedules = [
+//     {
+//       date: "2025-08-21",
+//       time: "10:00",
+//       description: "OO사 서비스 계약 고객 전화 상담",
+//     },
+//     {
+//       date: "2025-08-21",
+//       time: "13:00",
+//       description: "□□사 견적 산출을 위한 출장",
+//     },
+//   ];
+//
+//   return (
+//     <Container className="mt-4">
+//       <h5 className="fw-bold mb-3">가장 가까운 일정</h5>
+//       <ScheduleBox {...nearestSchedule} />
+//
+//       <h5 className="fw-bold mt-4 mb-3">다가오는 일정</h5>
+//       {upcomingSchedules.map((schedule, idx) => (
+//         <ScheduleBox key={idx} {...schedule} />
+//       ))}
+//     </Container>
+//   );
+// };
+//
+// export default ScheduleListGroup;
+
+// src/components/SalesMainPage/ScheduleListGroup.jsx
+import React from "react";
+import ScheduleBox from "./ScheduleBox";
+import "./ScheduleListGroup.css";
+
+const ScheduleListGroup = () => {
+  const nearestSchedule = {
+    date: "2025-08-20",
+    time: "09:00",
+    description: "XX사 물품 관련 발주 회의 미팅",
+  };
+
+  const upcomingSchedules = [
+    {
+      date: "2025-08-21",
+      time: "10:00",
+      description: "OO사 서비스 계약 고객 전화 상담",
+    },
+    {
+      date: "2025-08-21",
+      time: "13:00",
+      description: "□□사 견적 산출을 위한 출장",
+    },
+  ];
+
+  return (
+    <div className="schedule-list-group">
+      <h5 className="fw-bold mb-3">가장 가까운 일정</h5>
+      <ScheduleBox {...nearestSchedule} />
+
+      <h5 className="fw-bold mt-4 mb-3">다가오는 일정</h5>
+      <div className="upcoming-wrapper">
+        {upcomingSchedules.map((item, idx) => (
+          <ScheduleBox key={idx} {...item} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleListGroup;

--- a/propozal-frontend/src/pages/Login/Login.css
+++ b/propozal-frontend/src/pages/Login/Login.css
@@ -1,0 +1,119 @@
+/* Login.css */
+.login-wrapper {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  overflow: hidden;
+}
+
+.center-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background-color: #ccc;
+  z-index: 1;
+}
+
+.left-panel,
+.right-panel {
+  width: 50vw;
+  height: 100%;
+  padding: 2rem;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.left-panel {
+  background-color: #588157;
+  color: white;
+}
+
+.intro-content,
+.login-content {
+  width: 100%;
+  max-width: 400px; /* 반응형 콘텐츠 제한 */
+}
+
+.brand-title {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600; /* 가장 굵은 버전 */
+}
+
+.intro-content h2 {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 500;
+}
+
+.intro-content h4,
+.intro-content p {
+  font-family: 'Noto Sans KR', sans-serif;
+  font-weight: 300;
+}
+
+.slogan {
+  font-family: 'Noto Sans KR', sans-serif;
+  font-weight: 700;
+  font-size: 2.2rem; /* 크기 조절 가능: 예. 2rem까지도 OK */
+  line-height: 1.4;
+  margin-bottom: 1rem; /* 아래 여백 */
+  text-align: left; /* 혹은 center로 중앙 정렬 */
+}
+
+.highlight {
+  font-weight: 700;
+}
+
+.link-text {
+  color: #3A5A40;
+  font-weight: 400; /* 선택사항: 가독성 향상을 위한 적당한 굵기 */
+}
+
+.email-input::placeholder,
+.password-input::placeholder {
+  color: #d3d3d3;
+}
+
+.or-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem; /* 선과 텍스트 사이 간격 */
+  margin: 1rem 0; /* 전체 위아래 여백 */
+}
+
+.line {
+  flex: 1;
+  height: 1px;
+  background-color: #333; /* 라인 색상 */
+  border: none;
+}
+
+.or-text {
+  color: #666; /* "OR" 텍스트 색상 */
+  font-weight: 500;
+  padding: 0 0.5rem;
+  white-space: nowrap;
+}
+
+.form-control {
+  border: 1.5px solid #999; /* 진한 회색 테두리 */
+  box-shadow: none;       /* 불필요한 외곽 효과 제거 */
+}
+
+.btn-success {
+  background-color: #198754;
+  border: 1px solid #198754;
+  color: white;
+  font-weight: 600;
+}
+
+.btn-success:hover {
+  background-color: #BDDFBC;   /* 연한 초록 배경 */
+  color: #000000;              /* 검정 텍스트 */
+  border: 1px solid #000000;   /* 얇은 검정 실선 테두리 */
+}

--- a/propozal-frontend/src/pages/Login/Login.jsx
+++ b/propozal-frontend/src/pages/Login/Login.jsx
@@ -1,33 +1,97 @@
-// src/pages/Login.jsx
+import React from "react";
+import { useNavigate } from "react-router-dom";  // 🔗 navigate 추가
+import "./Login.css";
 
-import React from 'react';
-import { Form, Button, Container, Row, Col } from 'react-bootstrap';
+export default function LoginPage() {
+  const navigate = useNavigate();  // 🚀 페이지 이동 함수
 
-const Login = () => {
   return (
-    <Container className="pt-5">
-      <Row className="justify-content-center">
-        <Col md={6}>
-          <h3 className="text-center mb-4">로그인</h3>
-          <Form>
-            <Form.Group controlId="formEmail" className="mb-3">
-              <Form.Label>이메일 주소</Form.Label>
-              <Form.Control type="email" placeholder="example@propozal.com" />
-            </Form.Group>
+    <div className="login-wrapper">
+      {/* 가운데 고정선 (선택사항) */}
+      <div className="center-line" />
 
-            <Form.Group controlId="formPassword" className="mb-4">
-              <Form.Label>비밀번호</Form.Label>
-              <Form.Control type="password" placeholder="비밀번호 입력" />
-            </Form.Group>
+      {/* 좌측 소개 영역 */}
+      <div className="left-panel">
+        <div className="intro-content">
+          <h2 className="brand-title">PROPOZAL</h2>
+          <h4
+            style={{
+              fontWeight: 700,
+              fontSize: "2.0rem",  // 🔠 글자 크기 키우기
+              lineHeight: 1.4,
+              marginBottom: "1rem"
+            }}
+          >
+            빠르고 편하게,<br />
+            프로답게
+          </h4>
+          <p>프로포잘은 언제 어디서나 간편하게 사용할 수 있는<br />
+              견적 관리 솔루션입니다.</p>
+        </div>
+      </div>
 
-            <Button variant="success" type="submit" className="w-100">
-              로그인
-            </Button>
-          </Form>
-        </Col>
-      </Row>
-    </Container>
+      {/* 우측 로그인 영역 */}
+      <div className="right-panel">
+        <div className="login-content">
+          <h3 class="highlight">로그인</h3>
+          <form className="w-100" style={{ maxWidth: "100%", maxInlineSize: "400px" }}>
+            <div className="mb-3">
+              <label htmlFor="email" className="form-label">이메일 주소</label>
+{/*               <input type="email" className="form-control" id="email" placeholder="name@example.com" /> */}
+           <input
+             type="email"
+             className="form-control email-input"
+             id="email"
+             placeholder="name@example.com"
+           />
+            </div>
+
+            <div className="mb-4">
+              <label htmlFor="password" className="form-label">비밀번호</label>
+{/*               <input type="password" className="form-control" id="password" placeholder="********" /> */}
+            <input
+              type="password"
+              className="form-control password-input"
+              id="password"
+              placeholder="********"
+            />
+            </div>
+
+            <button type="submit" className="btn btn-success w-100 mb-1">SIGN IN</button>
+
+{/*             <div className="text-center my-2">OR</div> */}
+            <div className="or-divider">
+              <hr className="line" />
+              <span className="or-text">OR</span>
+              <hr className="line" />
+            </div>
+
+            <button className="btn btn-outline-dark w-100 mb-2">Sign in with Google</button>
+            <button className="btn btn-outline-warning w-100 mb-4">카카오 로그인</button>
+
+            <div className="d-flex justify-content-between flex-wrap gap-2">
+              {/* ✅ 회원가입 버튼으로 수정 */}
+              <button
+                type="button"
+                className="btn btn-link p-0 link-text"
+                onClick={() => navigate("/signup")}
+              >
+                계정이 없으신가요? <span style={{ fontWeight: 600 }}>회원가입</span>
+              </button>
+
+
+              <button
+                type="button"
+                className="btn btn-link p-0 link-text"
+                onClick={() => navigate("/forgot-password")}
+              >
+                아이디 찾기 / 비밀번호 찾기
+              </button>
+
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   );
-};
-
-export default Login;
+}

--- a/propozal-frontend/src/pages/SalesMainPage/SalesMainPage.jsx
+++ b/propozal-frontend/src/pages/SalesMainPage/SalesMainPage.jsx
@@ -1,0 +1,26 @@
+// src/pages/SalesMainPage/SalesMainPage.jsx
+import React from "react";
+import { Container } from "react-bootstrap";
+import SalesNavbar from "../../components/Navbar/SalesNavbar";
+import MainIconGroup from "../../components/SalesMainPage/MainIconGroup";
+import ScheduleListGroup from "../../components/SalesMainPage/ScheduleListGroup";
+import Footer from "../../components/Footer/Footer";
+
+const SalesMainPage = () => {
+  return (
+    <>
+      <SalesNavbar />
+
+      <main>
+        <Container className="pt-0 pb-0">
+          <MainIconGroup />
+          <ScheduleListGroup />
+        </Container>
+      </main>
+
+      <Footer />
+    </>
+  );
+};
+
+export default SalesMainPage;


### PR DESCRIPTION
[feat] 로그인, 영업 메인 페이지, 영업 네비 바 추가
- 로그인 페이지 추가
- sales main page 추가
- 영업 사원 로그인 시-영업사원 전용 네비 바 추가
* 백엔드 연동 안 됨+화면만 구현한 상태입니다.
* 모두 반응형 UI로 구현 완료하였습니다.

<img width="1024" height="576" alt="Screenshot 2025-08-06 at 11 00 21 AM" src="https://github.com/user-attachments/assets/1972e6b8-3c89-46a9-be8f-e6393a4494a0" />
<img width="1024" height="576" alt="Screenshot 2025-08-06 at 11 00 41 AM" src="https://github.com/user-attachments/assets/f1398cc3-2f8d-474b-9660-718dd103ed34" />


