### PR TITLE
[feat] 관리자 승인 API 구현 (회원 승인 및 승인 대기 목록 조회 기능)

### DIFF
--- a/propozal-backend/src/main/java/com/propozal/controller/UserController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/UserController.java
@@ -1,8 +1,9 @@
 package com.propozal.controller;
 
+import com.propozal.dto.user.PendingUserResponse;
 import com.propozal.dto.user.LoginRequest;
-import com.propozal.dto.user.SignupRequest;
 import com.propozal.dto.user.LoginResponse;
+import com.propozal.dto.user.SignupRequest;
 import com.propozal.dto.user.UserInfoResponse;
 import com.propozal.jwt.CustomUserDetails;
 import com.propozal.service.UserService;
@@ -12,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -50,6 +52,21 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         UserInfoResponse response = UserInfoResponse.from(userDetails.getUser());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/pending")
+    public ResponseEntity<List<PendingUserResponse>> getPendingUsers() {
+        return ResponseEntity.ok(userService.getPendingUsers());
+    }
+
+    @PostMapping("/{id}/approve")
+    public ResponseEntity<?> approveUser(@PathVariable Long id) {
+        userService.approveUser(id);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "유저 승인이 완료되었습니다.");
+
         return ResponseEntity.ok(response);
     }
 }

--- a/propozal-backend/src/main/java/com/propozal/dto/user/PendingUserResponse.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/user/PendingUserResponse.java
@@ -1,0 +1,19 @@
+package com.propozal.dto.user;
+
+import com.propozal.domain.User;
+import lombok.Getter;
+
+@Getter
+public class PendingUserResponse {
+    private Long id;
+    private String email;
+    private String name;
+    private String role;
+
+    public PendingUserResponse(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.name = user.getName();
+        this.role = user.getRole().name();
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/repository/UserRepository.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/UserRepository.java
@@ -3,11 +3,15 @@ package com.propozal.repository;
 import com.propozal.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+
+    List<User> findByIsActiveFalse();
 }
+
 
 

--- a/propozal-backend/src/main/java/com/propozal/service/UserService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/UserService.java
@@ -1,6 +1,7 @@
 package com.propozal.service;
 
 import com.propozal.domain.User;
+import com.propozal.dto.user.PendingUserResponse;
 import com.propozal.dto.user.LoginRequest;
 import com.propozal.dto.user.SignupRequest;
 import com.propozal.dto.user.LoginResponse;
@@ -10,7 +11,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -63,5 +68,19 @@ public class UserService {
         String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
 
         return new LoginResponse(accessToken, refreshToken);
+    }
+
+    public List<PendingUserResponse> getPendingUsers() {
+        return userRepository.findByIsActiveFalse()
+                .stream()
+                .map(PendingUserResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void approveUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+        user.setActive(true);
     }
 }


### PR DESCRIPTION
작업 개요
- 관리자 승인 기능을 위한 API 2종 구현

작업 상세 내용
- GET /api/auth/pending
  - 승인 대기 상태인 유저(is_active = false) 목록 조회
  - PendingUserResponse DTO를 통해 응답
- POST /api/auth/{id}/approve
  - 특정 유저 승인 처리 → is_active = true 변경
  - 승인 완료 메시지 반환

테스트 결과
- 회원가입 → 자동으로 is_active = false 저장 확인
- Postman으로 승인 대기 유저 조회 성공
- 승인 처리 후 응답 메시지 및 DB 상태 변경 확인
- 승인 후 다시 조회 시 리스트에서 제외됨