### PR TITLE
[feat] 견적서 메모 추가 기능

### DIFF
--- a/propozal-backend/src/main/java/com/propozal/controller/EstimateMemoController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/EstimateMemoController.java
@@ -1,0 +1,54 @@
+package com.propozal.controller;
+
+import com.propozal.dto.estimate.EstimateMemoRequest;
+import com.propozal.dto.estimate.EstimateMemoResponse;
+import com.propozal.jwt.CustomUserDetails;
+import com.propozal.service.EstimateMemoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/estimates/{estimateId}/memos")
+@RequiredArgsConstructor
+public class EstimateMemoController {
+
+    private final EstimateMemoService estimateMemoService;
+
+    @PostMapping
+    public ResponseEntity<Void> createMemo(
+            @PathVariable Long estimateId,
+            @RequestBody EstimateMemoRequest requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        estimateMemoService.createMemo(estimateId, userDetails.getUser().getId(), requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<EstimateMemoResponse>> getMemos(@PathVariable Long estimateId) {
+        return ResponseEntity.ok(estimateMemoService.getMemosByEstimate(estimateId));
+    }
+
+    @PutMapping("/{memoId}")
+    public ResponseEntity<Void> updateMemo(
+            @PathVariable Long memoId,
+            @RequestBody EstimateMemoRequest requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        estimateMemoService.updateMemo(memoId, userDetails.getUser().getId(), requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{memoId}")
+    public ResponseEntity<Void> deleteMemo(
+            @PathVariable Long memoId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        estimateMemoService.deleteMemo(memoId, userDetails.getUser().getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/domain/EstimateMemo.java
+++ b/propozal-backend/src/main/java/com/propozal/domain/EstimateMemo.java
@@ -1,0 +1,55 @@
+package com.propozal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "estimate_memos")
+public class EstimateMemo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "estimate_id", nullable = false)
+    private Estimate estimate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public EstimateMemo(Estimate estimate, User createdBy, String content) {
+        this.estimate = estimate;
+        this.createdBy = createdBy;
+        this.content = content;
+    }
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/dto/estimate/EstimateMemoRequest.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/estimate/EstimateMemoRequest.java
@@ -1,0 +1,8 @@
+package com.propozal.dto.estimate;
+
+import lombok.Getter;
+
+@Getter
+public class EstimateMemoRequest {
+    private String content;
+}

--- a/propozal-backend/src/main/java/com/propozal/dto/estimate/EstimateMemoResponse.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/estimate/EstimateMemoResponse.java
@@ -1,0 +1,25 @@
+package com.propozal.dto.estimate;
+
+import com.propozal.domain.EstimateMemo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class EstimateMemoResponse {
+    private Long id;
+    private String content;
+    private String createdByName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public EstimateMemoResponse(EstimateMemo memo) {
+        this.id = memo.getId();
+        this.content = memo.getContent();
+        this.createdByName = memo.getCreatedBy().getName(); // 필요시 DTO에서 꺼냄
+        this.createdAt = memo.getCreatedAt();
+        this.updatedAt = memo.getUpdatedAt();
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/repository/EstimateMemoRepository.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/EstimateMemoRepository.java
@@ -1,0 +1,11 @@
+package com.propozal.repository;
+
+import com.propozal.domain.EstimateMemo;
+import com.propozal.domain.Estimate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EstimateMemoRepository extends JpaRepository<EstimateMemo, Long> {
+    List<EstimateMemo> findByEstimate(Estimate estimate);
+}

--- a/propozal-backend/src/main/java/com/propozal/service/EstimateMemoService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/EstimateMemoService.java
@@ -1,0 +1,75 @@
+package com.propozal.service;
+
+import com.propozal.domain.Estimate;
+import com.propozal.domain.EstimateMemo;
+import com.propozal.domain.User;
+import com.propozal.dto.estimate.EstimateMemoRequest;
+import com.propozal.dto.estimate.EstimateMemoResponse;
+import com.propozal.repository.EstimateMemoRepository;
+import com.propozal.repository.EstimateRepository;
+import com.propozal.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EstimateMemoService {
+
+    private final EstimateMemoRepository estimateMemoRepository;
+    private final EstimateRepository estimateRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createMemo(Long estimateId, Long userId, EstimateMemoRequest requestDto) {
+        Estimate estimate = estimateRepository.findById(estimateId)
+                .orElseThrow(() -> new IllegalArgumentException("견적서를 찾을 수 없습니다."));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        EstimateMemo memo = EstimateMemo.builder()
+                .estimate(estimate)
+                .createdBy(user)
+                .content(requestDto.getContent())
+                .build();
+
+        estimateMemoRepository.save(memo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<EstimateMemoResponse> getMemosByEstimate(Long estimateId) {
+        Estimate estimate = estimateRepository.findById(estimateId)
+                .orElseThrow(() -> new IllegalArgumentException("견적서를 찾을 수 없습니다."));
+
+        return estimateMemoRepository.findByEstimate(estimate).stream()
+                .map(EstimateMemoResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateMemo(Long memoId, Long userId, EstimateMemoRequest requestDto) {
+        EstimateMemo memo = estimateMemoRepository.findById(memoId)
+                .orElseThrow(() -> new IllegalArgumentException("메모를 찾을 수 없습니다."));
+
+        if (!memo.getCreatedBy().getId().equals(userId)) {
+            throw new SecurityException("본인만 수정할 수 있습니다.");
+        }
+
+        memo.updateContent(requestDto.getContent());
+    }
+
+    @Transactional
+    public void deleteMemo(Long memoId, Long userId) {
+        EstimateMemo memo = estimateMemoRepository.findById(memoId)
+                .orElseThrow(() -> new IllegalArgumentException("메모를 찾을 수 없습니다."));
+
+        if (!memo.getCreatedBy().getId().equals(userId)) {
+            throw new SecurityException("본인만 삭제할 수 있습니다.");
+        }
+
+        estimateMemoRepository.delete(memo);
+    }
+}


### PR DESCRIPTION
## 주요 변경점
견적서 메모 작성 기능 추가

## 작성된 API
1. [POST] `/api/estimates/{estimateId}/memos` : `{estimateId}`의 견적서에 Body값의 메모를 추가합니다.
2. [GET] `/api/estimates/{estimateId}/memos` : `{estimateId}`의 견적서에 연결된 메모를 조회합니다.
3. [PUT] `/api/estimates/{estimateId}/memos/{memoId}` : `{estimateId}`의 견적서에 연결된 `{memoId}`의 메모를 Body값으로 수정합니다.
4. [DELETE] `/api/estimates/{estimateId}/memos/{memoId}` : `{estimateId}`의 견적서에 연결된 `{memoId}`의 메모를 삭제합니다.