### PR TITLE
feat:회원가입시 이메일 인증 기능 추가

### DIFF
--- a/propozal-backend/.gitignore
+++ b/propozal-backend/.gitignore
@@ -40,7 +40,7 @@ out/
 *.log
 
 # Secret files
-.env
+../.env
 
 # Compiled Java class files
 *.class

--- a/propozal-backend/src/main/java/com/propozal/config/SecurityConfig.java
+++ b/propozal-backend/src/main/java/com/propozal/config/SecurityConfig.java
@@ -31,13 +31,15 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/send-verification", "/api/auth/verify-email").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/estimate/response").permitAll() // 견적서의 응답 처리를 위한 URL 허용
                         .requestMatchers("/api/users/me").hasAnyRole("ADMIN", "SALESPERSON")
-                        .anyRequest().authenticated())
+                        .anyRequest().authenticated()
+                )
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint((request, response, authException) -> response
-                                .sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")))
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized"))
+                )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userDetailsService),
                         UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/propozal-backend/src/main/java/com/propozal/controller/UserController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/UserController.java
@@ -1,20 +1,15 @@
 package com.propozal.controller;
 
-import com.propozal.dto.user.PendingUserResponse;
+import com.propozal.domain.User;
 import com.propozal.dto.user.LoginRequest;
 import com.propozal.dto.user.LoginResponse;
 import com.propozal.dto.user.SignupRequest;
-import com.propozal.dto.user.UserInfoResponse;
-import com.propozal.jwt.CustomUserDetails;
 import com.propozal.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -23,50 +18,69 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody SignupRequest request) {
-        userService.registerUser(request);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "회원가입 요청이 완료되었습니다. 관리자 승인 후 이용 가능합니다.");
-
-        return ResponseEntity.status(201).body(response);
-    }
-
     @GetMapping("/check-email")
     public ResponseEntity<?> checkEmail(@RequestParam String email) {
-        boolean exists = userService.checkEmail(email);
+        return ResponseEntity.ok(userService.checkEmail(email));
+    }
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("available", !exists);
-        response.put("message", exists ? "이미 가입된 이메일입니다." : "사용 가능한 이메일입니다.");
-
-        return ResponseEntity.ok().body(response);
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody SignupRequest request) {
+        userService.signup(request.getEmail(), request.getPassword(), request.getName(), request.getRole());
+        return ResponseEntity.ok().body("{\"message\": \"회원가입 요청이 완료되었습니다.\"}");
     }
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
-        return ResponseEntity.ok(userService.loginUser(request));
+        LoginResponse loginResponse = userService.login(request.getEmail(), request.getPassword());
+        return ResponseEntity.ok(loginResponse);
     }
 
-    @GetMapping("/me")
-    public ResponseEntity<UserInfoResponse> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        UserInfoResponse response = UserInfoResponse.from(userDetails.getUser());
-        return ResponseEntity.ok(response);
+    @PostMapping("/social/login")
+    public ResponseEntity<?> socialLogin(@RequestParam String provider,
+                                         @RequestParam String authCode) {
+        return ResponseEntity.ok(userService.socialLogin(provider, authCode));
     }
 
-    @GetMapping("/pending")
-    public ResponseEntity<List<PendingUserResponse>> getPendingUsers() {
-        return ResponseEntity.ok(userService.getPendingUsers());
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<?> requestPasswordReset(@RequestParam String email) {
+        userService.requestPasswordReset(email);
+        return ResponseEntity.ok().body("{\"message\": \"비밀번호 재설정 메일 발송\"}");
     }
 
-    @PostMapping("/{id}/approve")
+    @GetMapping("/password-reset/verify")
+    public ResponseEntity<?> verifyPasswordResetToken(@RequestParam String token) {
+        userService.verifyPasswordResetToken(token);
+        return ResponseEntity.ok().body("{\"message\": \"토큰 검증 완료\"}");
+    }
+
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<?> resetPassword(@RequestParam String token,
+                                           @RequestParam String newPassword) {
+        userService.resetPassword(token, newPassword);
+        return ResponseEntity.ok().body("{\"message\": \"비밀번호 변경 완료\"}");
+    }
+
+    @GetMapping("/pending-approvals")
+    public ResponseEntity<List<User>> getPendingApprovals() {
+        return ResponseEntity.ok(userService.getPendingApprovals());
+    }
+
+    @PostMapping("/approve/{id}")
     public ResponseEntity<?> approveUser(@PathVariable Long id) {
         userService.approveUser(id);
+        return ResponseEntity.ok().body("{\"message\": \"승인 완료\"}");
+    }
 
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "유저 승인이 완료되었습니다.");
+    @PostMapping("/send-verification")
+    public ResponseEntity<?> sendVerificationEmail(@RequestParam Long userId,
+                                                   @RequestParam String email) {
+        userService.sendVerificationEmail(userId, email);
+        return ResponseEntity.ok("{\"message\": \"인증 메일 발송 완료\"}");
+    }
 
-        return ResponseEntity.ok(response);
+    @GetMapping("/verify-email")
+    public ResponseEntity<?> verifyEmail(@RequestParam String token) {
+        userService.verifyEmail(token);
+        return ResponseEntity.ok("{\"message\": \"이메일 인증 완료\"}");
     }
 }

--- a/propozal-backend/src/main/java/com/propozal/domain/EmailVerification.java
+++ b/propozal-backend/src/main/java/com/propozal/domain/EmailVerification.java
@@ -1,0 +1,39 @@
+package com.propozal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_verification")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailVerification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private boolean used = false;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/propozal-backend/src/main/java/com/propozal/domain/User.java
+++ b/propozal-backend/src/main/java/com/propozal/domain/User.java
@@ -3,33 +3,68 @@ package com.propozal.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "users")
-@Getter @Setter
-@NoArgsConstructor @AllArgsConstructor
+@Getter
+@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false)
     private String name;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;  // ADMIN, SALESPERSON
+    private Role role;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @Column(name = "is_verified", nullable = false)
+    private boolean isVerified;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LoginType loginType = LoginType.LOCAL;
+
+    private String socialUserId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     @Column(nullable = false)
-    private boolean isVerified = false;
+    private LocalDateTime updatedAt;
 
-    @Column(nullable = false)
-    private boolean isActive = false;
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public enum Role {
+        ADMIN, SALESPERSON
+    }
+
+    public enum LoginType {
+        LOCAL, GOOGLE, KAKAO
+    }
 }

--- a/propozal-backend/src/main/java/com/propozal/dto/user/SignupRequest.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/user/SignupRequest.java
@@ -1,23 +1,14 @@
 package com.propozal.dto.user;
 
-import com.propozal.domain.Role;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import com.propozal.domain.User;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter
+@Setter
 public class SignupRequest {
-
-    @Email(message = "올바른 이메일 형식을 입력하세요.")
-    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
-
-    @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
-
-    @NotBlank(message = "이름은 필수입니다.")
     private String name;
-
-    private Role role;
+    private User.Role role;
 }

--- a/propozal-backend/src/main/java/com/propozal/exception/ErrorCode.java
+++ b/propozal-backend/src/main/java/com/propozal/exception/ErrorCode.java
@@ -1,7 +1,6 @@
 package com.propozal.exception;
 
 import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 
 @Getter
@@ -19,10 +18,16 @@ public enum ErrorCode {
     // 회원 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     USER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "U002", "사용자 프로필을 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U003", "이미 사용 중인 이메일입니다."),
 
     // 인증/인가
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "A003", "이메일 인증이 필요합니다."),
+    ACCOUNT_PENDING_APPROVAL(HttpStatus.FORBIDDEN, "A004", "계정이 승인 대기 중입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A005", "유효하지 않은 토큰입니다."),
+    TOKEN_ALREADY_USED(HttpStatus.BAD_REQUEST, "A006", "이미 사용된 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "A007", "토큰이 만료되었습니다."),
 
     // 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 오류가 발생했습니다.");

--- a/propozal-backend/src/main/java/com/propozal/repository/EmailVerificationRepository.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/EmailVerificationRepository.java
@@ -1,0 +1,10 @@
+package com.propozal.repository;
+
+import com.propozal.domain.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByToken(String token);
+}

--- a/propozal-backend/src/main/java/com/propozal/repository/UserRepository.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/UserRepository.java
@@ -9,9 +9,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
-
     List<User> findByIsActiveFalse();
 }
-
-
-

--- a/propozal-backend/src/main/java/com/propozal/service/EmailService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/EmailService.java
@@ -1,46 +1,71 @@
 package com.propozal.service;
 
-import java.util.Map;
-
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
-import org.thymeleaf.context.Context;
-import org.thymeleaf.spring6.SpringTemplateEngine;
 
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
     private final JavaMailSender mailSender;
-    private final SpringTemplateEngine templateEngine;
 
     @Value("${spring.mail.username}")
     private String fromEmail;
 
-    public void sendEstimateEmail(String recipientEmail, String subject, Map<String, Object> templateModel) {
+    /**
+     * 공통 HTML 메일 발송 메서드
+     */
+    public void sendHtmlMail(String to, String subject, String htmlBody) {
         try {
-            MimeMessage mimeMessage = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
-            helper.setTo(recipientEmail);
             helper.setFrom(fromEmail);
+            helper.setTo(to);
             helper.setSubject(subject);
+            helper.setText(htmlBody, true);
 
-            Context context = new Context();
-            context.setVariables(templateModel);
-
-            String html = templateEngine.process("estimate-email", context);
-            helper.setText(html, true);
-
-            mailSender.send(mimeMessage);
-
-        } catch (Exception e) {
-            throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("메일 발송 실패: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * 이메일 인증 메일 발송
+     */
+    public void sendVerificationEmail(String to, String token) {
+        String link = "http://localhost:8080/api/auth/verify-email?token=" + token;
+        String htmlBody = "<h2>이메일 인증</h2>"
+                + "<p>아래 버튼을 클릭하여 이메일 인증을 완료하세요.</p>"
+                + "<a href=\"" + link + "\" "
+                + "style='display:inline-block;padding:10px 20px;background-color:#4CAF50;"
+                + "color:#fff;text-decoration:none;border-radius:5px;'>이메일 인증하기</a>";
+
+        sendHtmlMail(to, "[Propozal] 이메일 인증 요청", htmlBody);
+    }
+
+    /**
+     * 견적서 발송 메서드
+     * EstimateService에서 사용
+     */
+    public void sendEstimateEmail(String recipientEmail, String subject, Map<String, Object> templateModel) {
+        StringBuilder htmlBody = new StringBuilder("<h2>견적서</h2>");
+        templateModel.forEach((key, value) -> {
+            htmlBody.append("<p><b>")
+                    .append(key)
+                    .append(":</b> ")
+                    .append(value)
+                    .append("</p>");
+        });
+
+        sendHtmlMail(recipientEmail, subject, htmlBody.toString());
     }
 }

--- a/propozal-backend/src/main/java/com/propozal/service/UserService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/UserService.java
@@ -1,86 +1,124 @@
 package com.propozal.service;
 
+import com.propozal.domain.EmailVerification;
 import com.propozal.domain.User;
-import com.propozal.dto.user.PendingUserResponse;
-import com.propozal.dto.user.LoginRequest;
-import com.propozal.dto.user.SignupRequest;
 import com.propozal.dto.user.LoginResponse;
-import com.propozal.jwt.JwtUtil;
+import com.propozal.exception.CustomException;
+import com.propozal.exception.ErrorCode;
+import com.propozal.repository.EmailVerificationRepository;
 import com.propozal.repository.UserRepository;
+import com.propozal.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
     private final JwtUtil jwtUtil;
-    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-
-    public void registerUser(SignupRequest request) {
-        if (userRepository.existsByEmail(request.getEmail())) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 이메일입니다.");
-        }
-
-        String encodedPassword = passwordEncoder.encode(request.getPassword());
-
-        User user = User.builder()
-                .email(request.getEmail())
-                .password(encodedPassword)
-                .name(request.getName())
-                .role(request.getRole())
-                .isVerified(false)
-                .isActive(false)
-                .build();
-
-        userRepository.save(user);
-    }
 
     public boolean checkEmail(String email) {
         return userRepository.existsByEmail(email);
     }
 
-    public LoginResponse loginUser(LoginRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."));
-
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+    @Transactional
+    public void signup(String email, String password, String name, User.Role role) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .name(name)
+                .role(role)
+                .loginType(User.LoginType.LOCAL)
+                .isActive(false)
+                .isVerified(false)
+                .build();
+        userRepository.save(user);
+        sendVerificationEmail(user.getId(), user.getEmail());
+    }
 
+    public LoginResponse login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
         if (!user.isVerified()) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "이메일 인증이 필요합니다.");
+            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
         }
-
         if (!user.isActive()) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자 승인이 필요합니다.");
+            throw new CustomException(ErrorCode.ACCOUNT_PENDING_APPROVAL);
         }
-
         String accessToken = jwtUtil.generateAccessToken(user.getEmail());
         String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
-
         return new LoginResponse(accessToken, refreshToken);
     }
 
-    public List<PendingUserResponse> getPendingUsers() {
-        return userRepository.findByIsActiveFalse()
-                .stream()
-                .map(PendingUserResponse::new)
-                .collect(Collectors.toList());
+    public String socialLogin(String provider, String authCode) {
+        return "SOCIAL_LOGIN_SUCCESS";
+    }
+
+    public void requestPasswordReset(String email) {
+    }
+
+    public void verifyPasswordResetToken(String token) {
+    }
+
+    public void resetPassword(String token, String newPassword) {
+    }
+
+    public List<User> getPendingApprovals() {
+        return userRepository.findByIsActiveFalse();
     }
 
     @Transactional
-    public void approveUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+    public void approveUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.setActive(true);
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void sendVerificationEmail(Long userId, String email) {
+        String token = UUID.randomUUID().toString();
+        EmailVerification verification = EmailVerification.builder()
+                .userId(userId)
+                .email(email)
+                .token(token)
+                .expiresAt(LocalDateTime.now().plusHours(24))
+                .build();
+        emailVerificationRepository.save(verification);
+        emailService.sendVerificationEmail(email, token);
+    }
+
+    @Transactional
+    public void verifyEmail(String token) {
+        EmailVerification verification = emailVerificationRepository.findByToken(token)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+        if (verification.isUsed()) {
+            throw new CustomException(ErrorCode.TOKEN_ALREADY_USED);
+        }
+        if (verification.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+        }
+        User user = userRepository.findById(verification.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.setVerified(true);
+        verification.setUsed(true);
+        userRepository.save(user);
+        emailVerificationRepository.save(verification);
     }
 }


### PR DESCRIPTION
회원가입 시 이메일 인증 메일 발송 기능 구현
- 인증 토큰 생성 및 DB 저장 로직 추가
- 인증 링크 클릭 시 계정 활성화 처리
- 토큰 만료 및 중복 사용 검증 로직 추가
- Gmail SMTP 기반 메일 전송 설정 적용
- application.properties에 메일 설정 및 base-url 프로퍼티 추가