### PR TITLE
Feat: 사용자 활동 로그 시스템 도입 및 CSV/PDF 내보내기 추가

### DIFF
--- a/propozal-backend/build.gradle
+++ b/propozal-backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.itextpdf:itextpdf:5.5.13.3'
+    implementation 'com.opencsv:opencsv:5.9'
 	
 	implementation 'software.amazon.awssdk:s3:2.25.26'
 	implementation 'software.amazon.awssdk:auth:2.25.26'

--- a/propozal-backend/src/main/java/com/propozal/controller/ActivityLogController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/ActivityLogController.java
@@ -1,0 +1,51 @@
+package com.propozal.controller;
+
+import com.propozal.dto.admin.ActivityLogFilterRequest;
+import com.propozal.dto.admin.ActivityLogRequest;
+import com.propozal.dto.admin.ActivityLogResponse;
+import com.propozal.service.ActivityLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.ByteArrayInputStream;
+
+@RestController
+@RequestMapping("/activity-logs")
+@RequiredArgsConstructor
+public class ActivityLogController {
+
+    private final ActivityLogService activityLogService;
+
+    @PostMapping
+    public ActivityLogResponse record(@RequestBody ActivityLogRequest request) {
+        return activityLogService.record(request);
+    }
+
+    @GetMapping
+    public Page<ActivityLogResponse> list(ActivityLogFilterRequest filter) {
+        return activityLogService.search(filter);
+    }
+
+    @GetMapping(value = "/export.csv")
+    public ResponseEntity<InputStreamResource> exportCsv(ActivityLogFilterRequest filter) {
+        ByteArrayInputStream in = activityLogService.exportCsv(filter);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=activity-logs.csv")
+                .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+                .body(new InputStreamResource(in));
+    }
+
+    @GetMapping(value = "/export.pdf")
+    public ResponseEntity<InputStreamResource> exportPdf(ActivityLogFilterRequest filter) {
+        ByteArrayInputStream in = activityLogService.exportPdf(filter);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=activity-logs.pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(new InputStreamResource(in));
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/domain/ActivityActionType.java
+++ b/propozal-backend/src/main/java/com/propozal/domain/ActivityActionType.java
@@ -1,0 +1,15 @@
+package com.propozal.domain;
+
+public enum ActivityActionType {
+    LOG,
+    LOGIN,
+    LOGOUT,
+    CREATE,
+    UPDATE,
+    DELETE,
+    VIEW,
+    EXPORT,
+    CONTRACT_PROGRESS,
+    APPROVE,
+    REJECT
+}

--- a/propozal-backend/src/main/java/com/propozal/domain/ActivityLog.java
+++ b/propozal-backend/src/main/java/com/propozal/domain/ActivityLog.java
@@ -1,0 +1,62 @@
+package com.propozal.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "activity_logs",
+        indexes = {
+                @Index(name = "idx_activity_user", columnList = "user_id"),
+                @Index(name = "idx_activity_action", columnList = "actionType"),
+                @Index(name = "idx_activity_created_at", columnList = "createdAt")
+        })
+public class ActivityLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 100)
+    private String username; // 화면 표시 및 검색 성능을 위한 저장
+
+    @Column(length = 100)
+    private String userRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private ActivityActionType actionType;
+
+    @Column(length = 64)
+    private String ipAddress;
+
+    @Column(length = 255)
+    private String userAgent;
+
+    @Column(length = 100)
+    private String resourceType; // 예: ESTIMATE, COMPANY 등
+
+    @Column(length = 100)
+    private String resourceId; // 문자열로 저장(유연성)
+
+    @Lob
+    @Column(nullable = false)
+    private String message; // 원문 메시지(마스킹은 응답 시 적용)
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/propozal-backend/src/main/java/com/propozal/dto/admin/ActivityLogFilterRequest.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/admin/ActivityLogFilterRequest.java
@@ -1,0 +1,27 @@
+package com.propozal.dto.admin;
+
+import com.propozal.domain.ActivityActionType;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ActivityLogFilterRequest {
+    private Long userId;
+    private String username;
+    private ActivityActionType actionType;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime from;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime to;
+
+    private String resourceType;
+    private String resourceId;
+
+    private int page = 0;
+    private int size = 20;
+    private String sort = "createdAt,desc";
+}

--- a/propozal-backend/src/main/java/com/propozal/dto/admin/ActivityLogRequest.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/admin/ActivityLogRequest.java
@@ -1,0 +1,17 @@
+package com.propozal.dto.admin;
+
+import com.propozal.domain.ActivityActionType;
+import lombok.Data;
+
+@Data
+public class ActivityLogRequest {
+    private Long userId;            // 선택: 시스템 이벤트면 null 가능
+    private String username;        // 화면에 빠르게 표현하기 위해 저장 가능
+    private String userRole;        // 선택
+    private ActivityActionType actionType;
+    private String ipAddress;
+    private String userAgent;
+    private String resourceType;    // ex) ESTIMATE, COMPANY
+    private String resourceId;      // ex) 123
+    private String message;         // 원문 메시지 (마스킹 전)
+}

--- a/propozal-backend/src/main/java/com/propozal/dto/admin/ActivityLogResponse.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/admin/ActivityLogResponse.java
@@ -1,0 +1,23 @@
+package com.propozal.dto.admin;
+
+import com.propozal.domain.ActivityActionType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ActivityLogResponse {
+    private Long id;
+    private Long userId;
+    private String username;
+    private String userRole;
+    private ActivityActionType actionType;
+    private String ipAddress;
+    private String userAgent;
+    private String resourceType;
+    private String resourceId;
+    private String message; // 마스킹된 메시지
+    private LocalDateTime createdAt;
+}

--- a/propozal-backend/src/main/java/com/propozal/repository/ActivityLogRepository.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/ActivityLogRepository.java
@@ -1,0 +1,10 @@
+package com.propozal.repository;
+
+import com.propozal.domain.ActivityLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
+}

--- a/propozal-backend/src/main/java/com/propozal/repository/ActivityLogSpecifications.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/ActivityLogSpecifications.java
@@ -1,0 +1,39 @@
+package com.propozal.repository;
+
+import com.propozal.domain.ActivityLog;
+import com.propozal.dto.admin.ActivityLogFilterRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+public class ActivityLogSpecifications {
+
+    public static Specification<ActivityLog> build(ActivityLogFilterRequest f) {
+        Specification<ActivityLog> spec = (root, query, cb) -> cb.conjunction();
+
+        if (f == null) return spec;
+
+        if (f.getUserId() != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("user").get("id"), f.getUserId()));
+        }
+        if (StringUtils.hasText(f.getUsername())) {
+            String like = "%" + f.getUsername().toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.like(cb.lower(root.get("username")), like));
+        }
+        if (f.getActionType() != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("actionType"), f.getActionType()));
+        }
+        if (f.getFrom() != null) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("createdAt"), f.getFrom()));
+        }
+        if (f.getTo() != null) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("createdAt"), f.getTo()));
+        }
+        if (StringUtils.hasText(f.getResourceType())) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("resourceType"), f.getResourceType()));
+        }
+        if (StringUtils.hasText(f.getResourceId())) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("resourceId"), f.getResourceId()));
+        }
+        return spec;
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/service/ActivityLogMaskingUtil.java
+++ b/propozal-backend/src/main/java/com/propozal/service/ActivityLogMaskingUtil.java
@@ -1,0 +1,24 @@
+package com.propozal.service;
+
+public class ActivityLogMaskingUtil {
+
+    // 간단한 이메일 마스킹: user@example.com -> u***@example.com
+    public static String maskEmail(String input) {
+        if (input == null) return null;
+        return input.replaceAll("([a-zA-Z0-9_.\\-])([a-zA-Z0-9_.\\-]*)@", "$1***@");
+    }
+
+    // 간단한 전화번호 마스킹: 010-1234-5678 -> 010-****-5678, 01012345678 -> 010****5678
+    public static String maskPhone(String input) {
+        if (input == null) return null;
+        return input
+                .replaceAll("(01[016789])[ -]?(\\d{3,4})[ -]?(\\d{4})", "$1-****-$3")
+                .replaceAll("(\\d{2,3})-(\\d{3,4})-(\\d{4})", "$1-****-$3");
+    }
+
+    public static String mask(String message) {
+        String masked = maskEmail(message);
+        masked = maskPhone(masked);
+        return masked;
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/service/ActivityLogService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/ActivityLogService.java
@@ -1,0 +1,208 @@
+package com.propozal.service;
+
+import com.itextpdf.text.*;
+import com.propozal.domain.ActivityLog;
+import com.propozal.domain.User;
+import com.propozal.dto.admin.ActivityLogFilterRequest;
+import com.propozal.dto.admin.ActivityLogRequest;
+import com.propozal.dto.admin.ActivityLogResponse;
+import com.propozal.repository.ActivityLogRepository;
+import com.propozal.repository.UserRepository;
+import com.propozal.repository.ActivityLogSpecifications;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
+import com.opencsv.CSVWriter;
+import com.itextpdf.text.pdf.BaseFont;
+import com.itextpdf.text.pdf.PdfWriter;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityLogService {
+
+    private final ActivityLogRepository activityLogRepository;
+    private final UserRepository userRepository;
+
+    @Value("${activity-log.date-format:yyyy/MM/dd HH:mm:ss}")
+    private String dateFormat;
+
+    @Value("${activity-log.csv.header:id,createdAt,username,actionType,message}")
+    private String csvHeader;
+
+    @Value("${activity-log.export.text-pattern:%s [log] %s}")
+    private String textPattern;
+
+    @Value("${activity-log.default-sort:createdAt,desc}")
+    private String defaultSort;
+
+    private static final DateTimeFormatter LOG_TS_FORMAT = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+    private static final String[] CSV_HEADERS = {"id", "createdAt", "username", "actionType", "message"};
+
+    @Transactional
+    public ActivityLogResponse record(ActivityLogRequest req) {
+        User user = null;
+        if (req.getUserId() != null) {
+            user = userRepository.findById(req.getUserId()).orElse(null);
+        }
+
+        String username = req.getUsername();
+        String userRole = req.getUserRole();
+        if (user != null) {
+            if (username == null || username.isBlank()) {
+                username = user.getName();
+            }
+            if (userRole == null || userRole.isBlank()) {
+                userRole = user.getRole() != null ? user.getRole().name() : null;
+            }
+        }
+
+        ActivityLog entity = ActivityLog.builder()
+                .user(user)
+                .username(username)
+                .userRole(userRole)
+                .actionType(req.getActionType())
+                .ipAddress(req.getIpAddress())
+                .userAgent(req.getUserAgent())
+                .resourceType(req.getResourceType())
+                .resourceId(req.getResourceId())
+                .message(req.getMessage())
+                .build();
+        ActivityLog saved = activityLogRepository.save(entity);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ActivityLogResponse> search(ActivityLogFilterRequest f) {
+        Sort sort = buildSort(f.getSort());
+        Pageable pageable = PageRequest.of(Math.max(f.getPage(), 0), Math.max(f.getSize(), 1), sort);
+        return activityLogRepository.findAll(ActivityLogSpecifications.build(f), pageable)
+                .map(this::toResponse);
+    }
+
+    private Sort buildSort(String sortParam) {
+        String sp = (sortParam == null || sortParam.isBlank()) ? defaultSort : sortParam;
+        String[] parts = sp.split(",");
+        String prop = parts.length > 0 ? parts[0].trim() : "createdAt";
+        String dir = parts.length > 1 ? parts[1].trim() : "desc";
+        return "asc".equalsIgnoreCase(dir) ? Sort.by(prop).ascending() : Sort.by(prop).descending();
+    }
+
+    @Transactional(readOnly = true)
+    public ByteArrayInputStream exportCsv(ActivityLogFilterRequest f) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+             CSVWriter csv = new CSVWriter(osw)) {
+            // Resolve fmt and headers from config, fallback to constants
+            DateTimeFormatter fmt = (dateFormat != null && !dateFormat.isBlank())
+                    ? DateTimeFormatter.ofPattern(dateFormat)
+                    : LOG_TS_FORMAT;
+            String[] headers = (csvHeader != null && !csvHeader.isBlank())
+                    ? csvHeader.split("\\s*,\\s*")
+                    : CSV_HEADERS;
+
+            // Header
+            csv.writeNext(headers, false);
+
+            // Rows
+            activityLogRepository.findAll(ActivityLogSpecifications.build(f), Sort.by("createdAt").descending())
+                    .forEach(log -> {
+                        String created = log.getCreatedAt() != null ? log.getCreatedAt().format(fmt) : "";
+                        String action = (log.getActionType() != null) ? log.getActionType().name() : "";
+                        String msg = maskMessage(log.getMessage());
+                        String[] row = new String[] {
+                                String.valueOf(log.getId()),
+                                created,
+                                log.getUsername() == null ? "" : log.getUsername(),
+                                action,
+                                msg == null ? "" : msg
+                        };
+                        csv.writeNext(row, false);
+                    });
+            osw.flush();
+        } catch (Exception e) {
+            throw new IllegalStateException("CSV export failed", e);
+        }
+        return new ByteArrayInputStream(out.toByteArray());
+    }
+
+    @Transactional(readOnly = true)
+    public ByteArrayInputStream exportPdf(ActivityLogFilterRequest f) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Document document = new Document(PageSize.A4, 36, 36, 36, 36);
+        try {
+            PdfWriter.getInstance(document, out);
+            document.open();
+
+            // Title
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA, BaseFont.IDENTITY_H, BaseFont.EMBEDDED, 14);
+            document.add(new Paragraph("Activity Logs", titleFont));
+            document.add(new Paragraph("\n"));
+
+            // Resolve fmt and text pattern from config, fallback to defaults
+            DateTimeFormatter fmt = (dateFormat != null && !dateFormat.isBlank())
+                    ? DateTimeFormatter.ofPattern(dateFormat)
+                    : LOG_TS_FORMAT;
+            String pattern = (textPattern != null && !textPattern.isBlank())
+                    ? textPattern
+                    : "%s [log] %s";
+
+            // Body lines
+            Font bodyFont = FontFactory.getFont(FontFactory.HELVETICA, BaseFont.IDENTITY_H, BaseFont.EMBEDDED, 10);
+            activityLogRepository.findAll(ActivityLogSpecifications.build(f), Sort.by("createdAt").descending())
+                    .forEach(log -> {
+                        String created = log.getCreatedAt() != null ? log.getCreatedAt().format(fmt) : "";
+                        String line = String.format(pattern, created, maskMessage(log.getMessage()));
+                        try {
+                            document.add(new Paragraph(line, bodyFont));
+                        } catch (DocumentException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        } catch (Exception e) {
+            throw new IllegalStateException("PDF export failed", e);
+        } finally {
+            document.close();
+        }
+        return new ByteArrayInputStream(out.toByteArray());
+    }
+
+    private ActivityLogResponse toResponse(ActivityLog log) {
+        return ActivityLogResponse.builder()
+                .id(log.getId())
+                .userId(log.getUser() != null ? log.getUser().getId() : null)
+                .username(log.getUsername())
+                .userRole(log.getUserRole())
+                .actionType(log.getActionType())
+                .ipAddress(log.getIpAddress())
+                .userAgent(log.getUserAgent())
+                .resourceType(log.getResourceType())
+                .resourceId(log.getResourceId())
+                .message(maskMessage(log.getMessage()))
+                .createdAt(log.getCreatedAt())
+                .build();
+    }
+
+    private static String maskMessage(String message) {
+        return ActivityLogMaskingUtil.mask(message);
+    }
+
+    private static String safe(String s) {
+        return s == null ? "" : s.replaceAll(",", " ");
+    }
+
+    private static String quote(String s) {
+        if (s == null) return "";
+        String escaped = s.replace("\"", "\"\"");
+        return '"' + escaped + '"';
+    }
+}


### PR DESCRIPTION
도메인/엔티티
ActivityLog 엔티티 추가: User 연관, username/userRole, actionType, IP, User-Agent, resourceType/Id, message, createdAt 
조회 성능을 위한 인덱스: user, actionType, createdAt

DTO
ActivityLogRequest/Response/FilterRequest 추가(로그 생성, 응답 마스킹, 필터/페이지네이션 파라미터) 

저장소/검색
ActivityLogRepository (JpaRepository + JpaSpecificationExecutor) ActivityLogSpecifications: 필터 스펙 빌더 구현
Spring Data 3.5 deprecation 대응: Specification.where(null) → cb.conjunction()로 초기 스펙 대체 

서비스
ActivityLogService.record(): userId 제공 시 UserRepository로 조회/연결, username/userRole 자동 채움 
검색: 동적 필터 + 페이지네이션 + 정렬
마스킹: ActivityLogMaskingUtil로 이메일/전화번호 등 민감정보 마스킹 (Java 정규식 이스케이프 오류 수정)
내보내기:
  CSV: OpenCSV(CSVWriter) 사용으로 리팩토링, 헤더/필드 이스케이프 안전화 
  PDF: iText로 리팩토링(Document/PdfWriter), 제목/본문 추가 및 날짜 포맷 적용
하드코딩 제거 및 설정 외부화: activity-log.date-format, activity-log.csv.header, activity-log.export.text-pattern, activity-log.default-sort 

컨트롤러/엔드포인트
POST /activity-logs: 로그 기록
GET /activity-logs: 필터/페이지네이션 조회
GET /activity-logs/export.csv, /activity-logs/export.pdf: 내보내기

보안
@EnableMethodSecurity 활성화, 메서드 보안 
@PreAuthorize 적용 POST record: isAuthenticated()
GET list/export: hasRole('ADMIN')
SecurityFilterChain: 요청 매처로 동일 정책 적용(Defense-in-Depth) 빌드/의존성

iText 5.5.13.3 추가 (PDF)
OpenCSV 5.9 사용 (CSV)

기타
기본 정렬/포맷 등 설정값 미지정 시 안전한 기본값 사용
검증 방법

권한
비로그인: 모든 엔드포인트 401
일반 사용자: POST 200/201, GET(list/export) 403
ADMIN: 모든 엔드포인트 200

기능
userId만 제공 시 username/userRole 자동 채움 확인
필터(기간/사용자/액션/리소스) 및 페이지네이션, 정렬 동작 확인
CSV/PDF 내보내기 시 마스킹 적용 및 포맷/헤더/문자 인코딩 정상 여부 확인