### PR TITLE
feat:비밀번호 재설정 기능 3단계 구현 (이메일 발송 → 토큰 검증 → 비밀번호 변경)

### DIFF
--- a/propozal-backend/src/main/java/com/propozal/config/PasswordPolicy.java
+++ b/propozal-backend/src/main/java/com/propozal/config/PasswordPolicy.java
@@ -1,0 +1,25 @@
+package com.propozal.config;
+
+public final class PasswordPolicy {
+
+    private PasswordPolicy() {}
+
+    public static boolean isValid(String password, String email) {
+        if (password == null || password.length() < 8) return false;
+
+        int kinds = 0;
+        if (password.matches(".*[a-z].*")) kinds++;
+        if (password.matches(".*[A-Z].*")) kinds++;
+        if (password.matches(".*\\d.*")) kinds++;
+        if (password.matches(".*[^A-Za-z0-9].*")) kinds++;
+        if (kinds < 2) return false;
+
+        if (email != null) {
+            String local = email.contains("@") ? email.substring(0, email.indexOf('@')) : email;
+            if (!local.isBlank() && password.toLowerCase().contains(local.toLowerCase())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/controller/PasswordResetController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/PasswordResetController.java
@@ -1,0 +1,37 @@
+package com.propozal.controller;
+
+import com.propozal.dto.user.MessageResponse;
+import com.propozal.dto.user.PasswordResetConfirmRequest;
+import com.propozal.dto.user.PasswordResetRequestDto;
+import com.propozal.service.PasswordResetService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth/password-reset")
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    public PasswordResetController(PasswordResetService passwordResetService) {
+        this.passwordResetService = passwordResetService;
+    }
+
+    @PostMapping("/request")
+    public MessageResponse request(@Valid @RequestBody PasswordResetRequestDto req) {
+        passwordResetService.requestReset(req.getEmail());
+        return new MessageResponse("비밀번호 재설정 메일이 발송되었습니다.");
+    }
+
+    @GetMapping("/verify")
+    public MessageResponse verify(@RequestParam("token") String token) {
+        passwordResetService.verifyToken(token);
+        return new MessageResponse("토큰 검증 완료. 비밀번호 변경 가능");
+    }
+
+    @PostMapping("/confirm")
+    public MessageResponse confirm(@Valid @RequestBody PasswordResetConfirmRequest req) {
+        passwordResetService.confirmReset(req.getToken(), req.getNewPassword());
+        return new MessageResponse("비밀번호가 성공적으로 변경되었습니다.");
+    }
+}

--- a/propozal-backend/src/main/java/com/propozal/controller/UserController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/UserController.java
@@ -41,25 +41,6 @@ public class UserController {
         return ResponseEntity.ok(userService.socialLogin(provider, authCode));
     }
 
-    @PostMapping("/password-reset/request")
-    public ResponseEntity<?> requestPasswordReset(@RequestParam String email) {
-        userService.requestPasswordReset(email);
-        return ResponseEntity.ok().body("{\"message\": \"비밀번호 재설정 메일 발송\"}");
-    }
-
-    @GetMapping("/password-reset/verify")
-    public ResponseEntity<?> verifyPasswordResetToken(@RequestParam String token) {
-        userService.verifyPasswordResetToken(token);
-        return ResponseEntity.ok().body("{\"message\": \"토큰 검증 완료\"}");
-    }
-
-    @PostMapping("/password-reset/confirm")
-    public ResponseEntity<?> resetPassword(@RequestParam String token,
-                                           @RequestParam String newPassword) {
-        userService.resetPassword(token, newPassword);
-        return ResponseEntity.ok().body("{\"message\": \"비밀번호 변경 완료\"}");
-    }
-
     @GetMapping("/pending-approvals")
     public ResponseEntity<List<User>> getPendingApprovals() {
         return ResponseEntity.ok(userService.getPendingApprovals());

--- a/propozal-backend/src/main/java/com/propozal/domain/EmailVerification.java
+++ b/propozal-backend/src/main/java/com/propozal/domain/EmailVerification.java
@@ -19,6 +19,7 @@ public class EmailVerification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "user_id")
     private Long userId;
 
     @Column(nullable = false)

--- a/propozal-backend/src/main/java/com/propozal/dto/user/MessageResponse.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/user/MessageResponse.java
@@ -1,0 +1,11 @@
+package com.propozal.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MessageResponse {
+    private final String message;
+}
+

--- a/propozal-backend/src/main/java/com/propozal/dto/user/PasswordResetConfirmRequest.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/user/PasswordResetConfirmRequest.java
@@ -1,0 +1,19 @@
+package com.propozal.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PasswordResetConfirmRequest {
+    @NotBlank
+    private String token;
+
+    @NotBlank
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String newPassword;
+}

--- a/propozal-backend/src/main/java/com/propozal/dto/user/PasswordResetRequestDto.java
+++ b/propozal-backend/src/main/java/com/propozal/dto/user/PasswordResetRequestDto.java
@@ -1,0 +1,16 @@
+package com.propozal.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PasswordResetRequestDto {
+    @Email
+    @NotBlank
+    private String email;
+}

--- a/propozal-backend/src/main/java/com/propozal/exception/ErrorCode.java
+++ b/propozal-backend/src/main/java/com/propozal/exception/ErrorCode.java
@@ -6,21 +6,17 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-    // 카테고리 관련
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "카테고리를 찾을 수 없습니다."),
     CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "C002", "이미 존재하는 카테고리입니다."),
     CATEGORY_HAS_CHILDREN(HttpStatus.CONFLICT, "C003", "하위 카테고리가 존재하여 삭제할 수 없습니다."),
 
-    // 제품 관련
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "제품을 찾을 수 없습니다."),
     PRODUCT_ALREADY_EXISTS(HttpStatus.CONFLICT, "P002", "이미 존재하는 제품입니다."),
 
-    // 회원 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     USER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "U002", "사용자 프로필을 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U003", "이미 사용 중인 이메일입니다."),
 
-    // 인증/인가
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "A003", "이메일 인증이 필요합니다."),
@@ -28,8 +24,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A005", "유효하지 않은 토큰입니다."),
     TOKEN_ALREADY_USED(HttpStatus.BAD_REQUEST, "A006", "이미 사용된 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "A007", "토큰이 만료되었습니다."),
+    PASSWORD_POLICY_VIOLATION(HttpStatus.BAD_REQUEST, "A008", "비밀번호 정책을 위반했습니다."),
 
-    // 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/propozal-backend/src/main/java/com/propozal/repository/EmailVerificationRepository.java
+++ b/propozal-backend/src/main/java/com/propozal/repository/EmailVerificationRepository.java
@@ -3,8 +3,11 @@ package com.propozal.repository;
 import com.propozal.domain.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findByToken(String token);
+    boolean existsByEmailAndUsedFalseAndExpiresAtAfter(String email, LocalDateTime now);
+    Optional<EmailVerification> findTopByEmailAndUsedFalseAndExpiresAtAfterOrderByCreatedAtDesc(String email, LocalDateTime now);
 }

--- a/propozal-backend/src/main/java/com/propozal/service/EmailService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/EmailService.java
@@ -24,9 +24,6 @@ public class EmailService {
     @Value("${spring.mail.username}")
     private String fromEmail;
 
-    /**
-     * 공통 HTML 메일 발송 메서드
-     */
     public void sendHtmlMail(String to, String subject, String htmlBody) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
@@ -43,9 +40,6 @@ public class EmailService {
         }
     }
 
-    /**
-     * 이메일 인증 메일 발송
-     */
     public void sendVerificationEmail(String to, String token) {
         String link = "http://localhost:8080/api/auth/verify-email?token=" + token;
         String htmlBody = "<h2>이메일 인증</h2>"
@@ -57,10 +51,6 @@ public class EmailService {
         sendHtmlMail(to, "[Propozal] 이메일 인증 요청", htmlBody);
     }
 
-    /**
-     * 견적서 발송 메서드
-     * EstimateService에서 사용
-     */
     public void sendEstimateEmail(String recipientEmail, String subject, Map<String, Object> templateModel) {
         Context context = new Context();
         context.setVariables(templateModel);
@@ -68,5 +58,15 @@ public class EmailService {
         String htmlBody = templateEngine.process("estimate-email", context);
 
         sendHtmlMail(recipientEmail, subject, htmlBody);
+    }
+
+    public void sendPasswordResetMail(String to, String link) {
+        String htmlBody = "<h2>비밀번호 재설정</h2>"
+                + "<p>아래 버튼을 클릭해 비밀번호를 재설정하세요.</p>"
+                + "<a href=\"" + link + "\" "
+                + "style='display:inline-block;padding:10px 20px;background-color:#1976D2;"
+                + "color:#fff;text-decoration:none;border-radius:5px;'>비밀번호 재설정</a>"
+                + "<p>본 링크는 일정 시간 후 만료됩니다.</p>";
+        sendHtmlMail(to, "[Propozal] 비밀번호 재설정 안내", htmlBody);
     }
 }

--- a/propozal-backend/src/main/java/com/propozal/service/PasswordResetService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/PasswordResetService.java
@@ -1,0 +1,130 @@
+package com.propozal.service;
+
+import com.propozal.config.PasswordPolicy;
+import com.propozal.domain.EmailVerification;
+import com.propozal.domain.User;
+import com.propozal.exception.CustomException;
+import com.propozal.exception.ErrorCode;
+import com.propozal.repository.EmailVerificationRepository;
+import com.propozal.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class PasswordResetService {
+
+    private final UserRepository userRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final int EXPIRE_MINUTES = 30;
+
+    @Value("${app.base-url:http://localhost:8080}")
+    private String appBaseUrl;
+
+    public PasswordResetService(UserRepository userRepository,
+                                EmailVerificationRepository emailVerificationRepository,
+                                EmailService emailService,
+                                PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.emailVerificationRepository = emailVerificationRepository;
+        this.emailService = emailService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public void requestReset(String email) {
+        Optional<User> userOpt = userRepository.findByEmail(email);
+        if (userOpt.isEmpty()) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        boolean existsValid = emailVerificationRepository
+                .existsByEmailAndUsedFalseAndExpiresAtAfter(email, now);
+
+        String token;
+        if (existsValid) {
+            EmailVerification latest = emailVerificationRepository
+                    .findTopByEmailAndUsedFalseAndExpiresAtAfterOrderByCreatedAtDesc(email, now)
+                    .orElse(null);
+            token = latest != null ? latest.getToken() : issueToken(email);
+        } else {
+            token = issueToken(email);
+        }
+
+        String resetLink = buildBackendVerifyLink(token);
+        emailService.sendPasswordResetMail(email, resetLink);
+    }
+
+    private String issueToken(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String token = "PR-" + UUID.randomUUID();
+        EmailVerification ev = new EmailVerification();
+        ev.setUserId(user.getId());
+        ev.setEmail(email);
+        ev.setToken(token);
+        ev.setUsed(false);
+        ev.setExpiresAt(LocalDateTime.now().plusMinutes(EXPIRE_MINUTES));
+        emailVerificationRepository.save(ev);
+        return token;
+    }
+
+    private String buildBackendVerifyLink(String token) {
+        return appBaseUrl.replaceAll("/+$", "") + "/api/auth/password-reset/verify?token=" + token;
+    }
+
+    @Transactional(readOnly = true)
+    public void verifyToken(String token) {
+        EmailVerification ev = emailVerificationRepository.findByToken(token)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+
+        if (!token.startsWith("PR-")) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+        if (Boolean.TRUE.equals(ev.isUsed())) {
+            throw new CustomException(ErrorCode.TOKEN_ALREADY_USED);
+        }
+        if (ev.getExpiresAt() == null || ev.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+        }
+    }
+
+    @Transactional
+    public void confirmReset(String token, String newPassword) {
+        EmailVerification ev = emailVerificationRepository.findByToken(token)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+
+        if (!token.startsWith("PR-")) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+        if (Boolean.TRUE.equals(ev.isUsed())) {
+            throw new CustomException(ErrorCode.TOKEN_ALREADY_USED);
+        }
+        if (ev.getExpiresAt() == null || ev.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+        }
+
+        User user = userRepository.findByEmail(ev.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (!PasswordPolicy.isValid(newPassword, user.getEmail())) {
+            throw new CustomException(ErrorCode.PASSWORD_POLICY_VIOLATION);
+        }
+
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        ev.setUsed(true);
+        emailVerificationRepository.save(ev);
+    }
+}


### PR DESCRIPTION
### 구현 내용
- 비밀번호 재설정 요청 시 이메일로 재설정 링크 발송
  - 토큰 생성 및 `email_verification` 테이블에 저장
  - 토큰은 1회용 및 만료시간 설정(기본 30분)
- 사용자가 링크 클릭 시 토큰 검증 API(`/password-reset/verify`)로 유효성 확인
- 토큰 검증 완료 후 `/password-reset/confirm` API로 새 비밀번호 변경 가능
  - 비밀번호 BCrypt 해싱 저장
  - 토큰 사용 상태(`used=1`)로 변경하여 재사용 방지

### 변경 사항
- `EmailService` 추가: 이메일 발송 템플릿 구현
- `PasswordResetService` 구현: 토큰 발급, 검증, 사용처리
- `UserController` / `PasswordResetController` 수정: API 엔드포인트 추가
- `EmailVerification` 엔티티에 userId 필드 유지, 토큰 관리 로직 구현

### 테스트
- Postman을 통해 다음 시나리오 검증 완료
  1. 비밀번호 재설정 요청 시 이메일 수신
  2. 이메일 내 링크 클릭 시 토큰 검증 성공
  3. 토큰으로 비밀번호 변경 성공
  4. 변경된 비밀번호로 로그인 성공
  5. 사용된 토큰 재사용 시 에러 반환 확인

### 기타
- 기존 비밀번호로 로그인 시 401 UNAUTHORIZED 응답
- 변경 후 비밀번호로 로그인 시 정상 JWT 토큰 발급