### PR TITLE
feat: 회원가입에서 최고 관리자 선택시 이메일 인증만 진행 후 바로 로그인 가능하게 변경

### DIFF
--- a/propozal-backend/src/main/java/com/propozal/service/UserService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/UserService.java
@@ -39,14 +39,17 @@ public class UserService {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
+        // ✅ 최고 관리자는 이메일 인증만 끝나면 활성화, 영업사원은 관리자 승인 필요
+        boolean active = (role == User.Role.ADMIN);
+
         User user = User.builder()
                 .email(normalizedEmail)
                 .password(passwordEncoder.encode(password))
                 .name(name)
                 .role(role)
                 .loginType(User.LoginType.LOCAL)
-                .isActive(false)
-                .isVerified(false)
+                .isActive(active)   // ADMIN → true, SALESPERSON → false
+                .isVerified(false)  // 이메일 인증은 여전히 필요
                 .build();
         userRepository.save(user);
 
@@ -61,7 +64,7 @@ public class UserService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 🔹 상태값 분기 추가
+        // 🔹 상태값 분기
         if (!user.isVerified() && !user.isActive()) {
             throw new CustomException(ErrorCode.EMAIL_AND_APPROVAL_REQUIRED);
         }


### PR DESCRIPTION
## 작업 개요
- 회원가입 로직 수정

## 작업 상세 내용
- UserService.signup() 로직에서 `Role.ADMIN` 선택 시 `isActive=true` 로 저장되도록 변경
- 영업사원(`Role.SALESPERSON`)은 기존처럼 이메일 인증 + 관리자 승인 절차 필요
- 최고 관리자는 이메일 인증 완료 후 즉시 로그인 가능

