### PR TITLE
[refactor] 소셜 로그인 API 컨트롤러 중복 제거 및 책임 분리

### DIFF
--- a/propozal-backend/src/main/java/com/propozal/controller/SocialLoginController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/SocialLoginController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/auth/social")
+@RequestMapping("/api/auth/social")
 @RequiredArgsConstructor
 public class SocialLoginController {
 

--- a/propozal-backend/src/main/java/com/propozal/controller/UserController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/UserController.java
@@ -38,12 +38,6 @@ public class UserController {
         return ResponseEntity.ok(loginResponse);
     }
 
-    @PostMapping("/social/login")
-    public ResponseEntity<?> socialLogin(@RequestParam String provider,
-                                         @RequestParam String authCode) {
-        return ResponseEntity.ok(userService.socialLogin(provider, authCode));
-    }
-
     @GetMapping("/pending-approvals")
     public ResponseEntity<List<User>> getPendingApprovals() {
         return ResponseEntity.ok(userService.getPendingApprovals());
@@ -68,7 +62,6 @@ public class UserController {
         return ResponseEntity.ok("{\"message\": \"이메일 인증 완료\"}");
     }
 
-    // 로그인 시 추가한 코드
     @GetMapping("/me")
     public ResponseEntity<?> getMyPage(@AuthenticationPrincipal CustomUserDetails userDetails) {
         if (userDetails == null) {
@@ -76,8 +69,6 @@ public class UserController {
         }
 
         UserInfoResponse response = UserInfoResponse.from(userDetails.getUser());
-
         return ResponseEntity.ok(response);
     }
-
 }


### PR DESCRIPTION
## 작업 개요
- 소셜 로그인 API 중복 매핑 제거 및 컨트롤러 책임 분리

## 작업 상세 내용
- SocialLoginController: `/api/auth/social/login` 경로로 통일
- UserController: 중복된 `/social/login` 매핑 제거
- API 명세와 일치하도록 소셜 로그인 전담 컨트롤러로 정리
