### PR TITLE
[refactor] 백엔드 API 경로에서 /api prefix 제거

### DIFF
--- a/propozal-backend/src/main/java/com/propozal/controller/PasswordResetController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/PasswordResetController.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth/password-reset")
+@RequestMapping("/auth/password-reset")
 public class PasswordResetController {
 
     private final PasswordResetService passwordResetService;

--- a/propozal-backend/src/main/java/com/propozal/controller/SocialLoginController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/SocialLoginController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth/social")
+@RequestMapping("/auth/social")
 @RequiredArgsConstructor
 public class SocialLoginController {
 

--- a/propozal-backend/src/main/java/com/propozal/controller/UserController.java
+++ b/propozal-backend/src/main/java/com/propozal/controller/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/propozal-backend/src/main/java/com/propozal/service/EmailService.java
+++ b/propozal-backend/src/main/java/com/propozal/service/EmailService.java
@@ -8,7 +8,6 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.spring6.SpringTemplateEngine;
-
 import org.thymeleaf.context.Context;
 
 import java.util.Map;
@@ -40,7 +39,7 @@ public class EmailService {
     }
 
     public void sendVerificationEmail(String to, String token) {
-        String link = "http://localhost:8080/api/auth/verify-email?token=" + token;
+        String link = "http://localhost:8080/auth/verify-email?token=" + token;
         String htmlBody = "<h2>이메일 인증</h2>"
                 + "<p>아래 버튼을 클릭하여 이메일 인증을 완료하세요.</p>"
                 + "<a href=\"" + link + "\" "


### PR DESCRIPTION
## 작업 개요
- 백엔드 API 경로에서 `/api` prefix 제거

## 작업 상세 내용
- UserController @RequestMapping("/api/auth") → "/auth"
- SocialLoginController @RequestMapping("/api/auth/social") → "/auth/social"
- PasswordResetController @RequestMapping("/api/auth/password-reset") → "/auth/password-reset"
- EmailService 내 이메일 인증 링크 생성 시 "/api/auth/verify-email" → "/auth/verify-email" 으로 수정
