### PR TITLE
[fix] 로그인/회원가입/비밀번호 재설정 API 경로에서 /api prefix 제거

### DIFF
--- a/propozal-frontend/src/components/PasswordResetForm/PasswordResetForm.jsx
+++ b/propozal-frontend/src/components/PasswordResetForm/PasswordResetForm.jsx
@@ -8,7 +8,7 @@ const PasswordReset = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
-  const token = params.get("token"); // ✅ URL에서 토큰 추출
+  const token = params.get("token");
 
   const [email, setEmail] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -19,7 +19,8 @@ const PasswordReset = () => {
   // ✅ Step 1: 메일 발송
   const handleSendEmail = async () => {
     try {
-      await axios.post('http://localhost:8080/api/auth/password-reset/request', { email });
+      // ✅ /api 제거
+      await axios.post('http://localhost:8080/auth/password-reset/request', { email });
       alert('비밀번호 재설정 메일이 발송되었습니다. 이메일을 확인하세요.');
     } catch (error) {
       console.error(error);
@@ -35,7 +36,8 @@ const PasswordReset = () => {
     }
 
     try {
-      await axios.post('http://localhost:8080/api/auth/password-reset/confirm', {
+      // ✅ /api 제거
+      await axios.post('http://localhost:8080/auth/password-reset/confirm', {
         token,
         newPassword,
       });

--- a/propozal-frontend/src/pages/Login/Login.jsx
+++ b/propozal-frontend/src/pages/Login/Login.jsx
@@ -17,7 +17,8 @@ export default function LoginPage() {
     e.preventDefault();
 
     try {
-      const response = await axios.post("http://localhost:8080/api/auth/login", {
+      // ✅ /api 제거
+      const response = await axios.post("http://localhost:8080/auth/login", {
         email,
         password,
       });
@@ -26,20 +27,21 @@ export default function LoginPage() {
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
 
-      const userRes = await axiosInstance.get("/api/auth/me");
+      // ✅ /api 제거
+      const userRes = await axiosInstance.get("/auth/me");
       const user = userRes.data;
       localStorage.setItem("user", JSON.stringify(user));
 
       if (user.role === "SALESPERSON") {
-        navigate("/sales"); // 영업사원 홈
+        navigate("/sales");
       } else if (user.role === "ADMIN") {
-        navigate("/admin/test"); // 관리자 페이지
+        navigate("/admin/test");
       } else {
         alert("알 수 없는 사용자 권한입니다.");
       }
     } catch (error) {
       if (error.response) {
-        const msg = error.response.data.message;
+        const msg = error.response.data.message || "";
         if (msg.includes("이메일 인증과 관리자 승인")) {
           alert("이메일 인증과 관리자 승인이 모두 필요합니다.");
         } else if (msg.includes("이메일 인증")) {

--- a/propozal-frontend/src/pages/Signup/Signup.jsx
+++ b/propozal-frontend/src/pages/Signup/Signup.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";  // ✅ 기본 axios 사용
+import axios from "axios";
 
 // 🔹 카카오 인증 URL
 const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=3fdf6a1c367635a4dbc945a816c7a2b1&redirect_uri=http://localhost:5173/kakao/callback&response_type=code`;
@@ -9,7 +9,7 @@ const SignupPage = () => {
   const navigate = useNavigate();
 
   const [company, setCompany] = useState("");
-  const [name, setName] = useState("");   // ✅ 사용자 이름 상태 추가
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [emailChecked, setEmailChecked] = useState(false);
   const [password, setPassword] = useState("");
@@ -35,14 +35,15 @@ const SignupPage = () => {
     const signupData = {
       email,
       password,
-      name, // ✅ 사용자 이름 (company가 아니라 name으로 보냄)
+      name,
       role: jobTitle === "USER" ? "SALESPERSON" : jobTitle
     };
 
     setIsSubmitting(true);
 
     try {
-      await axios.post("http://localhost:8080/api/auth/signup", signupData);
+      // ✅ /api 제거
+      await axios.post("http://localhost:8080/auth/signup", signupData);
       alert("회원가입 성공!");
       navigate("/login");
     } catch (error) {
@@ -55,7 +56,8 @@ const SignupPage = () => {
 
   const handleEmailCheck = async () => {
     try {
-      const res = await axios.get(`http://localhost:8080/api/auth/check-email?email=${email}`);
+      // ✅ /api 제거
+      const res = await axios.get(`http://localhost:8080/auth/check-email?email=${email}`);
 
       if (res.data === true) {
         alert("이미 사용 중인 이메일입니다.");
@@ -99,7 +101,6 @@ const SignupPage = () => {
           />
         </div>
 
-        {/* ✅ 이름 입력 필드 추가 */}
         <div className="mb-3">
           <label>이름 *</label>
           <input
@@ -273,7 +274,6 @@ const SignupPage = () => {
           Google로 시작하기
         </button>
 
-        {/* ✅ 카카오 로그인 버튼 */}
         <button
           type="button"
           className="btn w-100 mb-4"


### PR DESCRIPTION
## 작업 개요
- 백엔드 API 경로 변경(/api 제거)에 맞춰 프론트엔드 코드 수정

## 작업 상세 내용
- Login.jsx
  - /api/auth/login → /auth/login
  - /api/auth/me → /auth/me
- Signup.jsx
  - /api/auth/signup → /auth/signup
  - /api/auth/check-email → /auth/check-email
- PasswordResetForm.jsx
  - /api/auth/password-reset/request → /auth/password-reset/request
  - /api/auth/password-reset/confirm → /auth/password-reset/confirm
